### PR TITLE
Fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # agents
 
-[code](./code) - A minimal coding agent in 200 lines of Python code using only the OpenAI Agents SDK.
+[code](./code) - A minimal coding agent in 200 lines of Python code using the OpenAI Agents SDK.
+
+[cua](./cua) - A minimal computer-use agent in 100 lines of Python code using the OpenAI Agents SDK.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # agents
+
+[code](./code) - A minimal coding agent in 200 lines of Python code using only the OpenAI Agents SDK.

--- a/code/README.md
+++ b/code/README.md
@@ -1,0 +1,53 @@
+
+# code
+
+A minimal coding agent inspired by [Raising the bar on SWE-bench](https://www.anthropic.com/engineering/swe-bench-sonnet) in 200 lines of Python code using the OpenAI Agents SDK.
+
+## Get started
+
+1. Clone this agents repository and a sample code repository
+```bash
+git clone https://github.com/lutzroeder/agents
+git clone https://github.com/lutzroeder/models
+```
+2. Install the OpenAI Agents SDK
+```bash
+pip install openai-agents
+```
+3. Set either the Anthropic **or** OpenAI API key
+```bash
+set ANTHROPIC_API_KEY=...
+set OPENAI_API_KEY=...
+```
+4. Example interaction with the agent:
+```bash
+python ./agents/code/main.py ./models/gpt2
+```
+```
+👤 User: Explain this code to me
+🤖 I'll help you understand the code in this repository. Let's first explore the repository structure to get a better understanding of what we're looking at.
+🔍 > view .
+Let's check the main code file, gpt2.py:
+🔍 > view gpt2.py
+Let's also check the README to understand more about this project:
+🔍 > view README.md
+# Explanation of the GPT-2 Implementation
+
+This repository contains a minimalist implementation of OpenAI's GPT-2 language model using PyTorch.
+...
+```
+```
+👤 User: document this code
+🤖 I'll help you document the code in this repository. Let's start by exploring the repository structure to understand what we're working with.
+🔍 > view .
+Let's examine the README.md file first to understand what this project is about:
+🔍 > view README.md
+Now let's look at the main Python file:
+🔍 > view gpt2.py
+Great! Based on the examination of the code, I see that the `gpt2.py` file already has some documentation, but we can improve it by adding more detailed docstrings to the classes and methods. Let's add comprehensive documentation to make the code more understandable.
+
+I'll now update the gpt2.py file with better documentation:
+📝 > str_replace gpt2.py
+Now let's add documentation to the encode and decode
+...
+```

--- a/code/main.py
+++ b/code/main.py
@@ -1,0 +1,199 @@
+import asyncio
+import collections
+import os
+import subprocess
+import sys
+
+import agents
+import openai
+
+location: str = "" # the project root location
+file_history: dict[str, list[str]] = collections.defaultdict(list)
+
+def read_file(path: str):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+def write_file(path: str, file: str):
+    with open(path, "w", encoding="utf-8") as f:
+        return f.write(file)
+
+def make_output(content: str, file: str, init_line: int = 1, expand_tabs: bool = True):
+    content = content if len(content) <= 16000 else content[:16000] + "<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>"
+    content = content.expandtabs() if expand_tabs else content
+    content = "\n".join([f"{i + init_line:6}\t{line}" for i, line in enumerate(content.split("\n"))])
+    return f"Here's the result of running `cat -n` on {file}:\n" + content + "\n"
+
+@agents.tool.function_tool
+def str_replace_editor(command: str, path: str, file_text: str | None = None, view_range: list[int] | None = None, old_str: str | None = None, new_str: str | None = None, insert_line: int | None = None):
+    """
+    Custom editing tool for viewing, creating and editing files
+    * State is persistent across command calls and discussions with the user
+    * If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep
+    * The `create` command cannot be used if the specified `path` already exists as a file
+    * If a `command` generates a long output, it will be truncated and marked with `<response clipped>`
+    * The `undo_edit` command will revert the last edit made to the file at `path`
+
+    Notes for using the `str_replace` command:
+    * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!
+    * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique
+    * The `new_str` parameter should contain the edited lines that should replace the `old_str`
+
+    Args:
+    command (str): The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.
+    file_text (str): Required parameter of `create` command, with the content of the file to be created.
+    insert_line (int): Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.
+    new_str (str): Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+    old_str (str): Required parameter of `str_replace` command containing the string in `path` to replace.
+    path (str): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
+    view_range (list of int): Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
+    """
+    if not os.path.commonpath([os.path.abspath(location), os.path.abspath(path)]):
+        raise ValueError(f"The path '{path}' is not within the directory '{location}'.")
+    if not os.path.isabs(path):
+        raise NotADirectoryError(f"The path '{path}' is not an absolute path, it should start with `/`.")
+    if command != "create" and not os.path.exists(path):
+        raise FileNotFoundError(f"The path '{path}' does not exist")
+    if command == "create" and os.path.exists(path):
+        raise FileExistsError(f"File already exists at '{path}' and cannot be overwritten using `create`")
+    if command != "view" and os.path.isdir(path):
+        raise IsADirectoryError(f"The path '{path}' is a directory and only the `view` command can be used on directories")
+    if command == "view":
+        print(f"\n\U0001F50D\033[32m > {command} {os.path.relpath(path, location)}{":"+(":".join(view_range)) if view_range else ""}\033[0m")
+        if os.path.isdir(path):
+            if view_range:
+                raise ValueError("The `view_range` parameter is not allowed when `path` points to a directory.")
+            result = []
+            for root, _, files in os.walk(path):
+                rel = os.path.relpath(root, path)
+                depth = 0 if rel == "." else rel.count(os.sep) + 1
+                if depth < 2 and (rel == '.' or not rel.startswith(".")):
+                    if rel != ".":
+                        result.append(os.path.join(".", rel, ""))
+                    for file in files:
+                        result.append(os.path.join(".", file) if rel == "." else os.path.join(".", rel, file))
+            return sorted(result)
+        content = read_file(path)
+        first = 1
+        if view_range:
+            if len(view_range) != 2 or not all(isinstance(i, int) for i in view_range):
+                raise ValueError("Invalid `view_range`. It should be a list of two integers.")
+            lines = content.split("\n")
+            line_count = len(lines)
+            first, last = view_range
+            if first < 1 or first > line_count:
+                raise ValueError(f"Invalid `view_range`: {view_range}. Its first element `{first}` should be within the range of lines of the file: {[1, line_count]}")
+            if last > line_count:
+                raise ValueError(f"Invalid `view_range`: {view_range}. Its second element `{last}` should be smaller than the number of lines in the file: `{line_count}`")
+            if last != -1 and last < first:
+                raise ValueError(f"Invalid `view_range`: {view_range}. Its second element `{last}` should be larger or equal than its first `{first}`")
+            content = "\n".join(lines[first - 1 :]) if last == -1 else "\n".join(lines[first - 1 : last])
+        return make_output(content, str(path), init_line=first)
+    print(f"\n\u270F\uFE0F\033[32m  > {command} {os.path.relpath(path, location)}\033[0m")
+    if command == "create":
+        if file_text is None:
+            raise ValueError("Parameter `file_text` is required for command 'create'.")
+        write_file(path, file_text)
+        file_history[path].append(file_text)
+        return f"File created successfully: '{path}'."
+    if command == "str_replace":
+        if old_str is None:
+            raise ValueError("Parameter `old_str` is required for command 'str_replace'.")
+        content = read_file(path).expandtabs()
+        old_str = old_str.expandtabs()
+        new_str = new_str.expandtabs() if new_str else ""
+        occurrences = content.count(old_str)
+        if occurrences == 0:
+            raise ValueError(f"No replacement was performed, old_str `{old_str}` did not appear verbatim in {path}")
+        if occurrences > 1:
+            raise ValueError(f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {[i + 1 for i, line in enumerate(content.split("\n")) if old_str in line]}. Please ensure it is unique.")
+        new_content = content.replace(old_str, new_str)
+        write_file(path, new_content)
+        file_history[path].append(content)
+        replacement = content.split(old_str)[0].count("\n")
+        start = max(0, replacement - 4)
+        end = replacement + 4 + new_str.count("\n")
+        snippet = "\n".join(new_content.split("\n")[start : end + 1])
+        output = make_output(snippet, f"a snippet of {path}", start + 1)
+        return f"The file {path} has been edited. {output}Review the changes and make sure they are as expected. Edit the file again if necessary."
+    if command == "insert":
+        if insert_line is None or new_str is None:
+            raise ValueError("Parameters `insert_line` and `new_str` are required for command 'insert'.")
+        content = read_file(path).expandtabs()
+        new_str = new_str.expandtabs()
+        lines = content.split("\n")
+        if insert_line < 0 or insert_line > len(lines):
+            raise ValueError(f"Invalid `insert_line` parameter: {insert_line}. It should be within the range of lines of the file: {[0, len(lines)]}")
+        new_lines = new_str.split("\n")
+        snippet = "\n".join(lines[max(0, insert_line - 4) : insert_line] + new_lines + lines[insert_line : insert_line + 4])
+        write_file(path, "\n".join(lines[:insert_line] + new_lines + lines[insert_line:]))
+        file_history[path].append(content)
+        output = make_output(snippet, "a snippet of the edited file", max(1, insert_line - 4 + 1))
+        return f"The file {path} has been edited. {output}Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."
+    if command == "undo_edit":
+        if not file_history[path]:
+            raise ValueError(f"No edit history found for {path}.")
+        old_text = file_history[path].pop()
+        write_file(path, old_text)
+        return f"Last edit to {path} undone successfully. {make_output(old_text, str(path))}"
+    raise ValueError(f'Unrecognized command {command}.')
+
+@agents.tool.function_tool
+def bash(command: str) -> str:
+    """
+    Run commands in a bash shell
+    When invoking this tool, the contents of the "command" parameter does NOT need to be XML-escaped.
+    You don't have access to the internet via this tool.
+    You do have access to a mirror of common linux and python packages via apt and pip.
+    State is persistent across command calls and discussions with the user.
+    To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.
+    Please avoid commands that may produce a very large amount of output.
+    Please run long lived commands in the background, e.g. 'sleep 10 &' or start a server in the background.
+
+    Args:
+    command (str): The bash command to run.
+    """
+    print(f"\n\U0001F5A5\033[32m  > {command}\033[0m")
+    return subprocess.run(command, shell=True, capture_output=True, text=True, check=True).stdout
+
+async def main():
+    if len(sys.argv) != 2 or not os.path.exists(sys.argv[1]):
+        print("Usage: python main.py <directory>")
+        sys.exit(1)
+    global location # pylint: disable=global-statement
+    location = os.path.abspath(sys.argv[1])
+    if os.getenv("ANTHROPIC_API_KEY"):
+        client = openai.AsyncOpenAI(api_key=os.getenv("ANTHROPIC_API_KEY"), base_url="https://api.anthropic.com/v1/")
+        model = agents.OpenAIChatCompletionsModel(model="claude-3-7-sonnet-latest", openai_client=client)
+        tools = [str_replace_editor, bash]
+    else:
+        model = "gpt-4.1"
+        tools = [str_replace_editor, bash, agents.WebSearchTool()]
+    instructions = f"""
+The code repository is in this directory: <location>{location}</location>
+
+Your task is to answer to the user or make the minimal changes to non-tests files in the <location> directory to ensure the user request is satisfied.
+
+Follow these steps:
+1. As a first step, it might be a good idea to explore the repo to familiarize yourself with its structure.
+2. If required, edit the sourcecode of the repo to address the user reuest.
+3. If the code changed, try to build the code and fix build errors if there are any!
+
+Your thinking should be thorough and so it's fine if it's very long.
+"""
+    agent = agents.Agent(name="code", model=model, instructions=instructions, tools=tools)
+    messages = []
+    while True:
+        user_request = input("\U0001F464 User: ")
+        print("\U0001F916 ", end="", flush=True)
+        messages.append({"role": "user", "content": user_request})
+        stream = agents.Runner.run_streamed(agent, messages, max_turns=100)
+        response = ""
+        async for event in stream.stream_events():
+            if event.type == 'raw_response_event' and event.data.type == "response.output_text.delta":
+                response += event.data.delta
+                print(event.data.delta, end="", flush=True)
+        messages.append({"role": "assistant", "content": response})
+        print("")
+
+asyncio.run(main())

--- a/code/main.py
+++ b/code/main.py
@@ -176,7 +176,7 @@ Your task is to answer to the user or make the minimal changes to non-tests file
 
 Follow these steps:
 1. As a first step, it might be a good idea to explore the repo to familiarize yourself with its structure.
-2. If required, edit the sourcecode of the repo to address the user reuest.
+2. If required, edit the source code of the repo to address the user request.
 3. If the code changed, try to build the code and fix build errors if there are any!
 
 Your thinking should be thorough and so it's fine if it's very long.

--- a/cua/README.md
+++ b/cua/README.md
@@ -1,0 +1,41 @@
+
+# cua
+
+A minimal computer-use agent in 100 lines of Python code using the OpenAI Agents SDK.
+
+## Get started
+
+1. Clone this repository
+```bash
+git clone https://github.com/lutzroeder/agents
+```
+2. Install the OpenAI Agents SDK and PyAutoGUI
+```bash
+pip install openai-agents pyautogui
+```
+3. Set OpenAI API key
+```bash
+set OPENAI_API_KEY=...
+```
+4. Example interaction with the agent:
+```bash
+python ./agents/cua/main.py
+```
+```
+👤 User: Open browser at lutzroeder.com
+   screenshot {}
+
+🤖 Action: Opening web browser, checking Edge icon
+   click {'button': 'left', 'x': 1388, 'y': 1544}
+   wait {}
+
+🤖 Action: Navigating to lutzroeder.com in Edge
+   click {'button': 'left', 'x': 1056, 'y': 104}
+   type {'text': 'lutzroeder.com'}
+   keypress {'keys': ['ENTER']}
+   wait {}
+
+🤖 Agent: The website lutzroeder.com is open in the browser...
+
+👤 User: 
+```

--- a/cua/main.py
+++ b/cua/main.py
@@ -1,0 +1,96 @@
+import asyncio
+import base64
+import io
+import platform
+
+import agents
+import pyautogui
+
+
+class LocalComputer(agents.AsyncComputer):
+
+    def __init__(self):
+        screenshot = pyautogui.screenshot()
+        self.size = screenshot.size
+
+    @property
+    def environment(self) -> agents.Environment:
+        system = platform.system().lower()
+        return "mac" if system == "darwin" else system
+
+    @property
+    def dimensions(self) -> tuple[int, int]:
+        return self.size
+
+    async def screenshot(self) -> str:
+        buffer = io.BytesIO()
+        pyautogui.screenshot().save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+    async def click(self, x: int, y: int, button: str = "left") -> None:
+        if 0 <= x < self.size[0] and 0 <= y < self.size[1]:
+            button = "middle" if button == "wheel" else button
+            pyautogui.moveTo(x, y, duration=0.1)
+            pyautogui.click(x, y, button=button)
+
+    async def double_click(self, x: int, y: int) -> None:
+        if 0 <= x < self.size[0] and 0 <= y < self.size[1]:
+            pyautogui.moveTo(x, y, duration=0.1)
+            pyautogui.doubleClick(x, y)
+
+    async def scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        pyautogui.scroll(-scroll_y, x=x, y=y)
+        pyautogui.hscroll(scroll_x, x=x, y=y)
+
+    async def type(self, text: str) -> None:
+        pyautogui.write(text)
+
+    async def wait(self, ms: int = 1000) -> None:
+        await asyncio.sleep(ms / 1000)
+
+    async def move(self, x: int, y: int) -> None:
+        pyautogui.moveTo(x, y, duration=0.1)
+
+    async def keypress(self, keys: list[str]) -> None:
+        keymap = {
+            "arrowdown": "down", "arrowleft": "left",
+            "arrowright": "right", "arrowup": "up",
+        }
+        keys = [keymap.get(key.lower(), key.lower()) for key in keys]
+        for key in keys:
+            pyautogui.keyDown(key)
+        for key in keys:
+            pyautogui.keyUp(key)
+
+    async def drag(self, path: list[tuple[int, int]]) -> None:
+        if len(path) >= 2:
+            pyautogui.moveTo(path[0][0], path[0][1], duration=0.5)
+            for point in path[1:]:
+                pyautogui.dragTo(point[0], point[1], duration=1.0, button="left")
+
+async def main():
+    agent = agents.Agent(
+        name="computer-use",
+        instructions="You are a helpful agent. DO NOT ask the user for confirmations.",
+        model="computer-use-preview",
+        model_settings=agents.ModelSettings(truncation="auto",
+            reasoning={"generate_summary": "concise"}),
+        tools=[agents.ComputerTool(LocalComputer())],
+    )
+    while True:
+        prompt = input("\U0001F464 User: ")
+        stream = agents.Runner.run_streamed(agent, prompt, max_turns=100)
+        async for event in stream.stream_events():
+            if event.type == 'run_item_stream_event':
+                if event.name == 'tool_called':
+                    action_args = vars(event.item.raw_item.action) | {}
+                    action = action_args.pop("type")
+                    print(f"   {action} {action_args}")
+                elif event.name == "reasoning_item_created":
+                    summary = "".join([_.text for _ in event.item.raw_item.summary])
+                    print(f"\n\U0001F916 Action: {summary}")
+            if event.type == 'raw_response_event':
+                if event.data.type == "response.output_text.done":
+                    print(f"\n\U0001F916 Agent: {event.data.text}\n")
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary
- fix typos in instructions string

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: code/main.py syntax error)*